### PR TITLE
Mejoras a código, excepciones y documentación (versión 0.1.2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,7 @@ use PhpCfdi\Rfc\Rfc;
 
 require 'vendor/autoload.php';
 
-$scraper = new Scraper(
-    new Client()
-);
+$scraper = Scraper::create();
 
 $rfc = Rfc::parse('YOUR_RFC');
 

--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,7 @@
         "php": ">=8.0",
         "ext-mbstring": "*",
         "ext-json": "*",
+        "ext-curl": "*",
         "guzzlehttp/guzzle": "^7.4",
         "phpcfdi/rfc": "^1.1",
         "symfony/css-selector": ">=6.0",
@@ -41,8 +42,7 @@
         "symfony/process": ">=6.0"
     },
     "require-dev": {
-        "ext-curl": "*",
-        "phpunit/phpunit": "^9.5"
+      "phpunit/phpunit": "^9.5"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -41,6 +41,7 @@
         "symfony/process": ">=6.0"
     },
     "require-dev": {
+        "ext-curl": "*",
         "phpunit/phpunit": "^9.5"
     },
     "autoload": {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,28 @@ versión, aunque sí su incorporación en la rama principal de trabajo, generalm
 
 ## Listado de cambios
 
+### Versión 0.1.2 2022-06-28
+
+#### Método fábrica de `Scraper`
+
+Se agrega el método para fabricar estáticamente un objeto `Scraper` con la configuración de `curl` adecuada.
+Lamentablemente, el sitio del SAT utiliza un esquema de seguridad anticuado que requiere configuración especial.
+
+#### Refactorización de excepciones
+
+Se agrega la excepción `CifDownloadException` que se genera cuando no se pudo descargar la página web de datos fiscales.
+
+Se agrega `CsfScraperException` como una interfaz vacía para identificar las excepciones generadas por esta librería.
+
+Se agregan las anotaciones `@throws` a los métodos para identificar que generan excepciones.
+
+#### Refactorizaciones
+
+Pequeñas limpiezas de código y a partes específicas:
+
+- Se refactoriza el código de la clase interna `CsfExtractor` para mejorar su intención.
+- Se refactoriza el código de la clase `PdfToText` para que use `ShellExec` al buscar por el ejecutable `pdftotext`.
+
 ### Versión 0.1.1 2022-06-27
 
 Se agregan los datos de `RFC` y `IDCIF` a la clase base `Persona`.

--- a/src/DataExtractor.php
+++ b/src/DataExtractor.php
@@ -18,6 +18,9 @@ final class DataExtractor implements DataExtractorInterface
         $this->html = $html;
     }
 
+    /**
+     * @throws CifNotFoundException
+     */
     public function extract(bool $isFisica): PersonaMoral|PersonaFisica
     {
         $html = $this->clearHtml($this->html);

--- a/src/DataExtractor.php
+++ b/src/DataExtractor.php
@@ -11,11 +11,8 @@ use Symfony\Component\DomCrawler\Crawler;
 
 final class DataExtractor implements DataExtractorInterface
 {
-    private string $html;
-
-    public function __construct(string $html)
+    public function __construct(private string $html)
     {
-        $this->html = $html;
     }
 
     /**

--- a/src/DataExtractor.php
+++ b/src/DataExtractor.php
@@ -37,12 +37,12 @@ final class DataExtractor implements DataExtractorInterface
             if (0 === $elem->filter('span')->count()) {
                 $property = $person->getKeyNameByIndex($index);
                 if (null !== $property) {
-                    $person->$property = trim($elem->text());
+                    $person->{$property} = trim($elem->text());
                 }
             }
         });
         $regimenes = $this->getRegimenes($crawler);
-        if (count($regimenes) > 0) {
+        if ([] !== $regimenes) {
             $person->addRegimenes(...$regimenes);
         }
         return $person;

--- a/src/Exceptions/CifDownloadException.php
+++ b/src/Exceptions/CifDownloadException.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCfdi\CsfScraper\Exceptions;
+
+use RuntimeException;
+use Throwable;
+
+final class CifDownloadException extends RuntimeException
+{
+    public function __construct(private string $url, Throwable $previous)
+    {
+        parent::__construct('The request has failed', previous: $previous);
+    }
+
+    public function getUrl(): string
+    {
+        return $this->url;
+    }
+}

--- a/src/Exceptions/CifDownloadException.php
+++ b/src/Exceptions/CifDownloadException.php
@@ -7,7 +7,7 @@ namespace PhpCfdi\CsfScraper\Exceptions;
 use RuntimeException;
 use Throwable;
 
-final class CifDownloadException extends RuntimeException
+final class CifDownloadException extends RuntimeException implements CsfScraperException
 {
     public function __construct(private string $url, Throwable $previous)
     {

--- a/src/Exceptions/CifNotFoundException.php
+++ b/src/Exceptions/CifNotFoundException.php
@@ -6,6 +6,6 @@ namespace PhpCfdi\CsfScraper\Exceptions;
 
 use Exception;
 
-final class CifNotFoundException extends Exception
+final class CifNotFoundException extends Exception implements CsfScraperException
 {
 }

--- a/src/Exceptions/CsfScraperException.php
+++ b/src/Exceptions/CsfScraperException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCfdi\CsfScraper\Exceptions;
+
+use Throwable;
+
+interface CsfScraperException extends Throwable
+{
+}

--- a/src/Exceptions/PdfReader/CifFromPdfNotFoundException.php
+++ b/src/Exceptions/PdfReader/CifFromPdfNotFoundException.php
@@ -5,7 +5,8 @@ declare(strict_types=1);
 namespace PhpCfdi\CsfScraper\Exceptions\PdfReader;
 
 use Exception;
+use PhpCfdi\CsfScraper\Exceptions\CsfScraperException;
 
-final class CifFromPdfNotFoundException extends Exception
+final class CifFromPdfNotFoundException extends Exception implements CsfScraperException
 {
 }

--- a/src/Exceptions/PdfReader/EmptyPdfContentException.php
+++ b/src/Exceptions/PdfReader/EmptyPdfContentException.php
@@ -5,7 +5,8 @@ declare(strict_types=1);
 namespace PhpCfdi\CsfScraper\Exceptions\PdfReader;
 
 use Exception;
+use PhpCfdi\CsfScraper\Exceptions\CsfScraperException;
 
-final class EmptyPdfContentException extends Exception
+final class EmptyPdfContentException extends Exception implements CsfScraperException
 {
 }

--- a/src/Exceptions/PdfReader/RfcFromPdfNotFoundException.php
+++ b/src/Exceptions/PdfReader/RfcFromPdfNotFoundException.php
@@ -5,7 +5,8 @@ declare(strict_types=1);
 namespace PhpCfdi\CsfScraper\Exceptions\PdfReader;
 
 use Exception;
+use PhpCfdi\CsfScraper\Exceptions\CsfScraperException;
 
-final class RfcFromPdfNotFoundException extends Exception
+final class RfcFromPdfNotFoundException extends Exception implements CsfScraperException
 {
 }

--- a/src/Exceptions/PdfReader/ShellExecException.php
+++ b/src/Exceptions/PdfReader/ShellExecException.php
@@ -4,10 +4,11 @@ declare(strict_types=1);
 
 namespace PhpCfdi\CsfScraper\Exceptions\PdfReader;
 
+use PhpCfdi\CsfScraper\Exceptions\CsfScraperException;
 use PhpCfdi\CsfScraper\PdfReader\ShellExecResult;
 use RuntimeException;
 
-final class ShellExecException extends RuntimeException
+final class ShellExecException extends RuntimeException implements CsfScraperException
 {
     /** @var string[] */
     private array $command;

--- a/src/Exceptions/PdfReader/ShellExecException.php
+++ b/src/Exceptions/PdfReader/ShellExecException.php
@@ -10,19 +10,12 @@ use RuntimeException;
 
 final class ShellExecException extends RuntimeException implements CsfScraperException
 {
-    /** @var string[] */
-    private array $command;
-    private ShellExecResult $result;
-
     /**
      * @param string[] $command
      */
-    public function __construct(string $message, array $command, ShellExecResult $result)
+    public function __construct(string $message, private array $command, private ShellExecResult $result)
     {
         parent::__construct($message);
-
-        $this->command = $command;
-        $this->result = $result;
     }
 
     /** @return string[] */

--- a/src/Exceptions/PdfReader/ShellExecException.php
+++ b/src/Exceptions/PdfReader/ShellExecException.php
@@ -5,8 +5,9 @@ declare(strict_types=1);
 namespace PhpCfdi\CsfScraper\Exceptions\PdfReader;
 
 use PhpCfdi\CsfScraper\PdfReader\ShellExecResult;
+use RuntimeException;
 
-final class ShellExecException extends \RuntimeException
+final class ShellExecException extends RuntimeException
 {
     /** @var string[] */
     private array $command;

--- a/src/Interfaces/ScraperInterface.php
+++ b/src/Interfaces/ScraperInterface.php
@@ -10,6 +10,15 @@ use PhpCfdi\Rfc\Rfc;
 
 interface ScraperInterface
 {
+    /**
+     * Obtain a PersonaMoral or PersonaFisica object with the information from SAT website
+     *
+     */
     public function obtainFromRfcAndCif(Rfc $rfc, string $idCIF): PersonaMoral|PersonaFisica;
+
+    /**
+     * Obtain a PersonaMoral or PersonaFisica object with the information from SAT website
+     * The RFC and CIF is taken from the "Constancia de Situación Fiscal" PDF file
+     */
     public function obtainFromPdfPath(string $path): PersonaMoral|PersonaFisica;
 }

--- a/src/PdfReader/CsfExtractor.php
+++ b/src/PdfReader/CsfExtractor.php
@@ -17,6 +17,9 @@ final class CsfExtractor
      */
     private array $lines;
 
+    /**
+     * @throws EmptyPdfContentException
+     */
     public function __construct(string $contents)
     {
         if ('' == $contents) {
@@ -27,40 +30,34 @@ final class CsfExtractor
 
     public function getRfc(): ?string
     {
-        $matchesIndex = $this->getMatchesIndex('RFC');
-        return $this->obtainCleanValue($matchesIndex);
+        $matchesText = $this->obtainFirstLineStartWith('RFC:');
+        return $this->obtainCleanValue($matchesText);
     }
 
     public function getCifId(): ?string
     {
-        $matchesIndex = $this->getMatchesIndex('idCIF');
-        return $this->obtainCleanValue($matchesIndex);
+        $matchesText = $this->obtainFirstLineStartWith('idCIF:');
+        return $this->obtainCleanValue($matchesText);
     }
 
-    /**
-     *
-     * @param string[] $matchesIndex
-     */
-    private function obtainCleanValue(array $matchesIndex): ?string
+    private function obtainFirstLineStartWith(string $searchable): string
     {
-        if (0 !== count($matchesIndex)) {
-            $values = explode(':', array_pop($matchesIndex));
-            if (isset($values[1])) {
-                return trim($values[1]);
+        foreach ($this->lines as $line) {
+            if (str_starts_with($line, $searchable)) {
+                return $line;
             }
         }
-        return null;
+
+        return '';
     }
 
-    /**
-     *
-     * @return string[]
-     */
-    private function getMatchesIndex(string $searchable): array
+    private function obtainCleanValue(string $entry): ?string
     {
-        return array_filter($this->lines, function ($haystack) use ($searchable) {
-            $pos = strpos($haystack, $searchable);
-            return is_int($pos);
-        });
+        $values = explode(':', $entry);
+        if (! isset($values[1])) {
+            return null;
+        }
+
+        return trim($values[1]);
     }
 }

--- a/src/PdfReader/PdfToText.php
+++ b/src/PdfReader/PdfToText.php
@@ -48,7 +48,6 @@ final class PdfToText
         $command = $this->buildCommand($path);
         $result = (new ShellExec($command))->run();
         if (0 !== $result->exitStatus()) {
-            print_r($result);
             throw new ShellExecException(
                 "Running pdftotext exit with error (exit status: {$result->exitStatus()})",
                 $command,

--- a/src/PdfReader/ShellExec.php
+++ b/src/PdfReader/ShellExec.php
@@ -59,7 +59,7 @@ final class ShellExec
                 $this->checkString($value, $allowEmpty, "Element $index");
             }
         } catch (Throwable $exception) {
-            throw new InvalidArgumentException($exceptionMessage, 0, $exception);
+            throw new InvalidArgumentException($exceptionMessage, previous: $exception);
         }
     }
 
@@ -71,7 +71,7 @@ final class ShellExec
         if (! $allowEmpty && '' === $value) {
             throw new InvalidArgumentException($exceptionMessagePrefix . ' is empty');
         }
-        if (boolval(preg_match('/[\x00-\x09\x0B\x0C\x0E-\x1F\x7F]/u', $value))) {
+        if (preg_match('/[\x00-\x09\x0B\x0C\x0E-\x1F\x7F]/u', $value)) {
             throw new InvalidArgumentException($exceptionMessagePrefix . ' contains control characters');
         }
     }

--- a/src/PdfReader/ShellExecResult.php
+++ b/src/PdfReader/ShellExecResult.php
@@ -9,7 +9,7 @@ namespace PhpCfdi\CsfScraper\PdfReader;
  *
  * @see ShellExec
  *
- * NOTE: Changes will not be considering a bracking compatibility change since this utility is for internal usage only
+ * NOTE: Changes will not be considering a breaking compatibility change since this utility is for internal usage only
  * @internal
  */
 final class ShellExecResult

--- a/src/Persona.php
+++ b/src/Persona.php
@@ -197,7 +197,7 @@ class Persona implements JsonSerializable
 
     public function __set(string $name, string $value): void
     {
-        $method = "set{$name}";
+        $method = "set$name";
         if (method_exists($this, $method)) {
             /** @var callable:mixed $callable */
             $callable = [$this, $method];

--- a/src/Regimenes.php
+++ b/src/Regimenes.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PhpCfdi\CsfScraper;
 
+use DateTimeImmutable;
 use JsonSerializable;
 
 class Regimenes implements JsonSerializable
@@ -31,7 +32,7 @@ class Regimenes implements JsonSerializable
     }
 
     /**
-     * @return array<int, array{regimen: string, regimen_id: string, fecha_alta: ?\DateTimeImmutable}>
+     * @return array<int, array{regimen: string, regimen_id: string, fecha_alta: ?DateTimeImmutable}>
      */
     public function toArray(): array
     {
@@ -42,7 +43,7 @@ class Regimenes implements JsonSerializable
     }
 
     /**
-      * @return array<int, array{regimen: string, regimen_id: string, fecha_alta: ?\DateTimeImmutable}>
+      * @return array<int, array{regimen: string, regimen_id: string, fecha_alta: ?DateTimeImmutable}>
       */
     public function jsonSerialize(): mixed
     {

--- a/src/Scraper.php
+++ b/src/Scraper.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PhpCfdi\CsfScraper;
 
+use GuzzleHttp\Client;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\GuzzleException;
 use PhpCfdi\CsfScraper\Exceptions\PdfReader\CifFromPdfNotFoundException;
@@ -22,6 +23,13 @@ class Scraper implements ScraperInterface
     public function __construct(ClientInterface $client)
     {
         $this->client = $client;
+    }
+
+    public static function create(): self
+    {
+        return new self(new Client([
+            'curl' => [CURLOPT_SSL_CIPHER_LIST => 'DEFAULT@SECLEVEL=1'],
+        ]));
     }
 
     /**

--- a/src/Scraper.php
+++ b/src/Scraper.php
@@ -15,6 +15,9 @@ use PhpCfdi\CsfScraper\PdfReader\PdfToText;
 use PhpCfdi\Rfc\Exceptions\InvalidExpressionToParseException;
 use PhpCfdi\Rfc\Rfc;
 
+/**
+ * Main class to obtain the data from a "Persona Moral" or a "Persona Física" from SAT website
+ */
 class Scraper implements ScraperInterface
 {
     private ClientInterface $client;
@@ -25,6 +28,9 @@ class Scraper implements ScraperInterface
         $this->client = $client;
     }
 
+    /**
+     * Factory method to create a scraper object with configuration that simply works
+     */
     public static function create(): self
     {
         return new self(new Client([
@@ -33,6 +39,8 @@ class Scraper implements ScraperInterface
     }
 
     /**
+     * Obtain a PersonaMoral or PersonaFisica object with the information from SAT website
+     *
      * @throws Exceptions\CifDownloadException
      * @throws Exceptions\CifNotFoundException
      */
@@ -47,6 +55,9 @@ class Scraper implements ScraperInterface
     }
 
     /**
+     * Obtain a PersonaMoral or PersonaFisica object with the information from SAT website
+     * The RFC and CIF is taken from the "Constancia de Situación Fiscal" PDF file
+     *
      * @param string $path
      * @return PersonaMoral|PersonaFisica
      * @throws Exceptions\CifNotFoundException
@@ -72,6 +83,8 @@ class Scraper implements ScraperInterface
     }
 
     /**
+     * Helper method to extract the text information from PDF to plain text
+     *
      * @param string $path
      * @return string
      * @throws Exceptions\PdfReader\ShellExecException when call to pdftotext fail
@@ -83,6 +96,8 @@ class Scraper implements ScraperInterface
     }
 
     /**
+     * Helper method to download the webpage that contains all the "Persona" information from SAT website
+     *
      * @throws Exceptions\CifDownloadException
      */
     protected function obtainHtml(string $uri): string

--- a/src/Scraper.php
+++ b/src/Scraper.php
@@ -38,6 +38,9 @@ class Scraper implements ScraperInterface
         return $person;
     }
 
+    /**
+     * @throws InvalidExpressionToParseException
+     */
     public function obtainFromPdfPath(string $path): PersonaMoral|PersonaFisica
     {
         $contents = $this->pdfToTextContent($path);

--- a/src/Scraper.php
+++ b/src/Scraper.php
@@ -20,12 +20,10 @@ use PhpCfdi\Rfc\Rfc;
  */
 class Scraper implements ScraperInterface
 {
-    private ClientInterface $client;
     public static string $url = 'https://siat.sat.gob.mx/app/qr/faces/pages/mobile/validadorqr.jsf?D1=10&D2=1&D3=%s_%s';
 
-    public function __construct(ClientInterface $client)
+    public function __construct(private ClientInterface $client)
     {
-        $this->client = $client;
     }
 
     /**

--- a/src/Scraper.php
+++ b/src/Scraper.php
@@ -39,6 +39,12 @@ class Scraper implements ScraperInterface
     }
 
     /**
+     * @param string $path
+     * @return PersonaMoral|PersonaFisica
+     * @throws Exceptions\CifNotFoundException
+     * @throws Exceptions\PdfReader\CifFromPdfNotFoundException
+     * @throws Exceptions\PdfReader\EmptyPdfContentException
+     * @throws Exceptions\PdfReader\RfcFromPdfNotFoundException
      * @throws InvalidExpressionToParseException
      */
     public function obtainFromPdfPath(string $path): PersonaMoral|PersonaFisica
@@ -60,7 +66,7 @@ class Scraper implements ScraperInterface
     /**
      * @param string $path
      * @return string
-     * @throws \PhpCfdi\CsfScraper\Exceptions\PdfReader\ShellExecException when call to pdftotext fail
+     * @throws Exceptions\PdfReader\ShellExecException when call to pdftotext fail
      */
     protected function pdfToTextContent(string $path): string
     {

--- a/tests/Unit/Persona/Traits/PersonaTrait.php
+++ b/tests/Unit/Persona/Traits/PersonaTrait.php
@@ -9,10 +9,10 @@ trait PersonaTrait
     private function setAndGetProperty(string $complementFunction, string $value): mixed
     {
         /** @var callable:void $setMethod */
-        $setMethod = [$this->person, "set{$complementFunction}"];
-        call_user_func($setMethod, ...[$value]);
+        $setMethod = [$this->person, "set$complementFunction"];
+        call_user_func($setMethod, $value);
         /** @var callable:void $getMethod */
-        $getMethod = [$this->person, "get{$complementFunction}"];
+        $getMethod = [$this->person, "get$complementFunction"];
         return call_user_func($getMethod);
     }
 


### PR DESCRIPTION
## Método fábrica de `Scraper`

Se agrega el método para fabricar estáticamente un objeto `Scraper` con la configuración de `curl` adecuada.
Lamentablemente, el sitio del SAT utiliza un esquema de seguridad anticuado que requiere configuración especial.

## Refactorización de excepciones

Se agrega la excepción `CifDownloadException` que se genera cuando no se pudo descargar la página web de datos fiscales.

Se agrega `CsfScraperException` como una interfaz vacía para identificar las excepciones generadas por esta librería.

Se agregan las anotaciones `@throws` a los métodos para identificar que generan excepciones.

## Refactorizaciones

Pequeñas limpiezas de código y a partes específicas:

- Se refactoriza el código de la clase interna `CsfExtractor` para mejorar su intención.
- Se refactoriza el código de la clase `PdfToText` para que use `ShellExec` al buscar por el ejecutable `pdftotext`.

