### PR TITLE
docs: fix docs to existing methods.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,11 @@ $scraper = Scraper::create();
 
 $rfc = Rfc::parse('YOUR_RFC');
 
-$person = $scraper->data(rfc: $rfc, idCIF: 'ID_CIF');
+$person = $scraper->obtainFromRfcAndCif(rfc: $rfc, idCIF: 'ID_CIF');
+
+// También puedes obtener los datos de la persona directamente del archivo local PDF
+// (Ten en cuenta que esta funcionalidad requiere de tener instalado popper-utils en tu servidor).
+$person = $scraper->obtainFromPdfPath('LOCAl_PDF_FILE_PATH');
 
 // puedes acceder a los datos de la persona (moral o física) usando los métodos incluidos:
 if($rfc->isFisica()) {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,9 @@ Usamos [Versionado Semántico 2.0.0](SEMVER.md) por lo que puedes usar esta libr
 
 ## Cambios no liberados en una versión
 
+- El ejemplo del `README.md` mostraba que se obtenían los datos usando el método `$scraper->data()`, sin embargo este método ya no existe más y el método usado es: `$scraper->obtainFromRfcAndCif()`.
+- Se agrega a la documentación cómo obtener los datos usando la ruta local del archivo PDF a través del método `$scraper->obtainFromPdfPath()`.
+
 Pueden aparecer cambios no liberados que se integran a la rama principal, pero no ameritan una nueva liberación de
 versión, aunque sí su incorporación en la rama principal de trabajo, generalmente se tratan de cambios en el desarrollo.
 


### PR DESCRIPTION
-El ejemplo del `README.md` mostraba que se obtenían los datos usando el método `$scraper->data()` , sin embargo este método ya no existe más y el método usado es: `$scraper->obtainFromRfcAndCif()`.
- Se agrega a la documentación como obtener los datos usando la ruta local del archivo PDF a través del método `$scraper->obtainFromPdfPath()`.