### PR TITLE
fix:  regimenId no se obtiene correctamente cuando el régimen es 622

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,7 @@ Usamos [Versionado Semántico 2.0.0](SEMVER.md) por lo que puedes usar esta libr
 
 - El ejemplo del `README.md` mostraba que se obtenían los datos usando el método `$scraper->data()`, sin embargo este método ya no existe más y el método usado es: `$scraper->obtainFromRfcAndCif()`.
 - Se agrega a la documentación cómo obtener los datos usando la ruta local del archivo PDF a través del método `$scraper->obtainFromPdfPath()`.
+- Se arregla la obtención del `régimen_id` 622 (Actividades Agrícolas, Ganaderas, Silvícolas y Pesqueras) debido a que en la página del SAT se muestra como: Actividades Agrícolas, Ganaderas, Silvícolas y Pesqueras PM.
 
 Pueden aparecer cambios no liberados que se integran a la rama principal, pero no ameritan una nueva liberación de
 versión, aunque sí su incorporación en la rama principal de trabajo, generalmente se tratan de cambios en el desarrollo.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,14 +6,16 @@ Usamos [Versionado Semántico 2.0.0](SEMVER.md) por lo que puedes usar esta libr
 
 ## Cambios no liberados en una versión
 
-- El ejemplo del `README.md` mostraba que se obtenían los datos usando el método `$scraper->data()`, sin embargo este método ya no existe más y el método usado es: `$scraper->obtainFromRfcAndCif()`.
-- Se agrega a la documentación cómo obtener los datos usando la ruta local del archivo PDF a través del método `$scraper->obtainFromPdfPath()`.
-- Se arregla la obtención del `régimen_id` 622 (Actividades Agrícolas, Ganaderas, Silvícolas y Pesqueras) debido a que en la página del SAT se muestra como: Actividades Agrícolas, Ganaderas, Silvícolas y Pesqueras PM.
-
 Pueden aparecer cambios no liberados que se integran a la rama principal, pero no ameritan una nueva liberación de
 versión, aunque sí su incorporación en la rama principal de trabajo, generalmente se tratan de cambios en el desarrollo.
 
 ## Listado de cambios
+
+### Versión 0.1.3 2022-10-25
+
+- El ejemplo del `README.md` mostraba que se obtenían los datos usando el método `$scraper->data()`, sin embargo este método ya no existe más y el método usado es: `$scraper->obtainFromRfcAndCif()`.
+- Se agrega a la documentación cómo obtener los datos usando la ruta local del archivo PDF a través del método `$scraper->obtainFromPdfPath()`.
+- Se elimina de regímenes la palabra PM, que viene en algunos regímenes como "Actividades Agrícolas, Ganaderas, Silvícolas y Pesqueras PM".
 
 ### Versión 0.1.2 2022-06-28
 

--- a/src/Regimen.php
+++ b/src/Regimen.php
@@ -113,7 +113,7 @@ class Regimen implements JsonSerializable
     public function setRegimen(string $regimen): void
     {
         $this->regimen = $regimen;
-        $regimenAsText = trim(str_replace(['Régimen de las', 'Régimen de los', 'Régimen de', 'Régimen'], '', $regimen));
+        $regimenAsText = trim(str_replace(['Régimen de las', 'Régimen de los', 'Régimen de', 'Régimen', 'PM'], '', $regimen));
         $this->regimenId = $this->searchRegimenIdByText($regimenAsText);
     }
 

--- a/tests/Unit/Regimen/SetRegimenTest.php
+++ b/tests/Unit/Regimen/SetRegimenTest.php
@@ -31,6 +31,7 @@ class SetRegimenTest extends TestCase
             ['Sociedades Cooperativas de Producción que optan por diferir sus ingresos', '620'],
             ['Incorporación Fiscal', '621'],
             ['Actividades Agrícolas, Ganaderas, Silvícolas y Pesqueras', '622'],
+            ['Actividades Agrícolas, Ganaderas, Silvícolas y Pesqueras PM', '622'],
             ['Opcional para Grupos de Sociedades', '623'],
             ['Coordinados', '624'],
             ['Régimen de las Actividades Empresariales con ingresos a través de Plataformas Tecnológicas', '625'],


### PR DESCRIPTION
Cuando el régimen de la persona moral es 622(Actividades Agrícolas, Ganaderas, Silvícolas y Pesqueras). La página objetivo del scraper regresa: Actividades Agrícolas, Ganaderas, Silvícolas y Pesqueras PM. Por lo tanto el id de este régimen no se obtenía correctamente. Debido a esto se agregó  `PM` a la lista de palabras a las cuales se les aplica la función `str_replace` para homogeneizar el nombre del régimen.