### PR TITLE
Correcciones de regímenes más estrictas

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,10 @@ versión, aunque sí su incorporación en la rama principal de trabajo, generalm
 
 ## Listado de cambios
 
+### Versión 0.1.4 2022-10-25
+
+- Se hacen más estrictas las correcciones de los regímenes usando expresiones regulares.
+
 ### Versión 0.1.3 2022-10-25
 
 - El ejemplo del `README.md` mostraba que se obtenían los datos usando el método `$scraper->data()`, sin embargo este método ya no existe más y el método usado es: `$scraper->obtainFromRfcAndCif()`.

--- a/src/Regimen.php
+++ b/src/Regimen.php
@@ -113,7 +113,7 @@ class Regimen implements JsonSerializable
     public function setRegimen(string $regimen): void
     {
         $this->regimen = $regimen;
-        $regimenAsText = trim(str_replace(['Régimen de las', 'Régimen de los', 'Régimen de', 'Régimen', 'PM'], '', $regimen));
+        $regimenAsText = preg_replace(['/^Régimen( de las| de los| de|) /u', '/ PM$/'], '', $regimen);
         $this->regimenId = $this->searchRegimenIdByText($regimenAsText);
     }
 

--- a/src/Regimen.php
+++ b/src/Regimen.php
@@ -113,6 +113,7 @@ class Regimen implements JsonSerializable
     public function setRegimen(string $regimen): void
     {
         $this->regimen = $regimen;
+        /** @var string $regimenAsText PHPStan: It is impossible here to return NULL*/
         $regimenAsText = preg_replace(['/^Régimen( de las| de los| de|) /u', '/ PM$/'], '', $regimen);
         $this->regimenId = $this->searchRegimenIdByText($regimenAsText);
     }


### PR DESCRIPTION
Antes: se sustituían palabras y se quitaban espacios.
Después: se usan expresiones regulares que definen dónde deben estar los textos a sustituir junto con los espacios.